### PR TITLE
docs: 添加对接平台的`agileboot`链接，采用`Java（SpringBoot）`语言

### DIFF
--- a/docs/01.指南/03.生态/04.对接平台的前后端项目.md
+++ b/docs/01.指南/03.生态/04.对接平台的前后端项目.md
@@ -12,6 +12,10 @@ permalink: /pages/opensource/
 
 [前端代码](https://github.com/hb0730/boot-admin-ui) [后端代码](https://github.com/hb0730/boot-admin) [预览地址](https://boot.hb0730.com/next)(登录用户名：`admin` 密码：`123456`) **所在分支: v5**
 
+#### AgileBoot
+
+[前端代码](https://github.com/valarchie/AgileBoot-Front-End) [后端代码](https://github.com/valarchie/AgileBoot-Back-End) [预览地址](http://www.agileboot.cc)(登录用户名：`admin` 密码：`admin123`)
+
 ### Go
 
 #### go-admin-server


### PR DESCRIPTION
Hi   大佬
我集成了您的前端项目做了一个目前相对完整齐全的全栈项目。   
可以放在文档中吗。